### PR TITLE
Fix stuff for Gradle 2.12

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.12-bin.zip

--- a/src/main/java/co/tomlee/gradle/plugins/jflex/JFlexPlugin.java
+++ b/src/main/java/co/tomlee/gradle/plugins/jflex/JFlexPlugin.java
@@ -7,6 +7,7 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.plugins.DslObject;
 import org.gradle.api.internal.tasks.DefaultSourceSet;
+import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSet;
@@ -17,10 +18,12 @@ import java.util.concurrent.Callable;
 
 public final class JFlexPlugin implements Plugin<Project> {
     private final FileResolver fileResolver;
+    private final DirectoryFileTreeFactory directoryFileTreeFactory;
 
     @Inject
-    public JFlexPlugin(final FileResolver fileResolver) {
+    public JFlexPlugin(final FileResolver fileResolver, final DirectoryFileTreeFactory directoryFileTreeFactory) {
         this.fileResolver = fileResolver;
+        this.directoryFileTreeFactory = directoryFileTreeFactory;
     }
 
     @Override
@@ -44,7 +47,10 @@ public final class JFlexPlugin implements Plugin<Project> {
                 // 1. Add a new 'jflex' virtual directory mapping
                 //
                 final JFlexVirtualSourceDirectoryImpl jflexSourceSet =
-                    new JFlexVirtualSourceDirectoryImpl(((DefaultSourceSet) sourceSet).getDisplayName(), fileResolver);
+                    new JFlexVirtualSourceDirectoryImpl(
+                            ((DefaultSourceSet) sourceSet).getDisplayName(),
+                            fileResolver,
+                            directoryFileTreeFactory);
                 new DslObject(sourceSet).getConvention().getPlugins().put("jflex", jflexSourceSet);
                 final String srcDir = String.format("src/%s/jflex", sourceSet.getName());
                 jflexSourceSet.getJflex().srcDir(srcDir);

--- a/src/main/java/co/tomlee/gradle/plugins/jflex/JFlexTask.java
+++ b/src/main/java/co/tomlee/gradle/plugins/jflex/JFlexTask.java
@@ -3,22 +3,41 @@ package co.tomlee.gradle.plugins.jflex;
 import groovy.lang.Closure;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.SourceTask;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.artifacts.ResolvedConfiguration;
+import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.process.JavaExecSpec;
 
 import java.io.File;
+import java.util.Set;
 
 public class JFlexTask extends SourceTask {
     private FileCollection jflexClasspath;
     private File outputDirectory;
 
+    private String mainClass = "jflex.Main";
+
+    public void setMainClass(final String mainClass) {
+        this.mainClass = mainClass;
+    }
+
+    public void mainClass(final String mainClass) {
+        this.mainClass = mainClass;
+    }
+
+    @Input
+    public String getMainClass() {
+        return mainClass;
+    }
+
     @TaskAction
     public void generate() throws Exception {
         getProject().javaexec(new Closure(this) {
             public void doCall(JavaExecSpec javaExecSpec) {
-                javaExecSpec.setMain("jflex.Main")
+                javaExecSpec.setMain(mainClass)
                         .setClasspath(getProject().getConfigurations().getByName("jflex"))
                         .args("-d")
                         .args(getOutputDirectory())

--- a/src/main/java/co/tomlee/gradle/plugins/jflex/JFlexVirtualSourceDirectoryImpl.java
+++ b/src/main/java/co/tomlee/gradle/plugins/jflex/JFlexVirtualSourceDirectoryImpl.java
@@ -4,14 +4,18 @@ import groovy.lang.Closure;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.file.DefaultSourceDirectorySet;
 import org.gradle.api.internal.file.FileResolver;
+import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.util.ConfigureUtil;
 
 public class JFlexVirtualSourceDirectoryImpl implements JFlexVirtualSourceDirectory {
     private final SourceDirectorySet jflex;
 
-    public JFlexVirtualSourceDirectoryImpl(final String parentDisplayName, FileResolver fileResolver) {
+    public JFlexVirtualSourceDirectoryImpl(
+            final String parentDisplayName,
+            final FileResolver fileResolver,
+            final DirectoryFileTreeFactory directoryFileTreeFactory) {
         final String displayName = String.format("%s JFle source", parentDisplayName);
-        this.jflex = new DefaultSourceDirectorySet(displayName, fileResolver);
+        this.jflex = new DefaultSourceDirectorySet(displayName, fileResolver, directoryFileTreeFactory);
         this.jflex.getFilter().include("**/*.l", "**/*.jflex");
     }
 


### PR DESCRIPTION
cc @anthraxx -- sorry for the lag, I somehow missed your bug report in my inbox noise. This fixes #3. If it looks good to you, I'll land it & cut a release over the weekend.

Noticed the version of jflex used in @JesusFreke's project (1.4.x) has no `jflex.Main` class (instead, it's `JFlex.Main`), so added a `mainClass` property to generate*JFlexSource. Usage is something like:

``` groovy
generateJFlexSource {
    mainClass = 'JFlex.Main'
    outputDirectory = new File(outputDirectory, 'org/jf/smali')
}
```

Not entirely sure how this ever worked for older versions of jflex, but it's getting a bit late to go spelunking. Once I fixed the 2.12 breakage I couldn't get smali building without changing mainClass too (at least on my Debian desktop). Might take a closer look over the weekend.

If it's not obvious, 0.0.3 will not be compatible with versions of gradle prior to 2.12 as a result of this change. (Probably serves me right for reaching into internal Gradle packages. Would you believe I was young and naive?)
